### PR TITLE
Support for 2-Kanal-Aktor

### DIFF
--- a/examples/homeassistant/custom_components/duofern/cover.py
+++ b/examples/homeassistant/custom_components/duofern/cover.py
@@ -20,7 +20,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     # Add devices
     to_add = [DuofernShutter(device['id'], device['name'], stick, hass) for device in stick.config['devices'] if
-              not device['id'].startswith('46') and not device['id'] in hass.data[DOMAIN]['devices'].keys()]
+              not (device['id'].startswith('46') or device['id'].startswith('43')) and not device['id'] in hass.data[DOMAIN]['devices'].keys()]
     add_devices(to_add)
 
 

--- a/examples/homeassistant/custom_components/duofern/light.py
+++ b/examples/homeassistant/custom_components/duofern/light.py
@@ -32,7 +32,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     # Add devices
     to_add = [DuofernLight(device['id'], device['name'], stick, hass) for device in stick.config['devices'] if
-              device['id'].startswith('46') and not device['id'] in hass.data[DOMAIN]['devices'].keys()]
+              (device['id'].startswith('46') or device['id'].startswith('43')) and not device['id'] in hass.data[DOMAIN]['devices'].keys()]
     add_devices(to_add)
 
 

--- a/pyduofern/duofern.py
+++ b/pyduofern/duofern.py
@@ -183,15 +183,11 @@ class Duofern(object):
             # Universalaktor -- not tested yet
             elif code[0:2] == "43":  # pragma: no cover
                 self.update_state(code, "state", "OK", "1")
-                module_definition01 = self.modules['by_code'][code + "01"]
+                module_definition01 = self.modules['by_code'][code]
                 if not module_definition01:
                     DoTrigger("global", "UNDEFINED DUOFERN_code+_01 DUOFERN code+01")
-                    module_definition01 = self.modules['by_code'][code + "01"]
 
-                module_definition02 = self.modules['by_code'][code + "02"]
-                if not module_definition02:
-                    DoTrigger("global", "UNDEFINED DUOFERN_code+_02 DUOFERN code02")
-                    module_definition02 = self.modules['by_code'][code + "02"]
+                module_definition02 = None
 
             if module_definition01:
                 hash = module_definition01

--- a/pyduofern/duofern_stick.py
+++ b/pyduofern/duofern_stick.py
@@ -270,6 +270,11 @@ class DuofernStick(object):
         threading.Timer(10, self.stop_unpair).start()
         self.unpairing = True
 
+    def remote(self, code, timeout=10):
+        self.send(duoRemotePair.replace('yyyyyy', code))
+        threading.Timer(timeout, self.stop_pair).start()
+        self.pairing = True
+
     def test_callback(self, arg):
         self.duofern_parser.parse(arg)
 

--- a/scripts/duofern_cli.py
+++ b/scripts/duofern_cli.py
@@ -52,6 +52,9 @@ parser.add_argument('--unpair', action='store_true',
                          'CONFIGFILE',
                     default=False)
 
+parser.add_argument('--remote',
+                    help='Pair by code. Added devices are also added to CONFIGFILE',
+                    metavar='DEVICE_ID', default=None)
 
 parser.add_argument('--pairtime', help='time to wait for pairing requests', metavar="SECONDS", default=60, type=int)
 
@@ -153,6 +156,14 @@ class DuofernCLI(Cmd):
                 print("Please use an integer number to indicate TIMEOUT in seconds")
         print("Starting pairing mode... waiting  {} seconds".format(int(timeout)))
         self.stick.unpair(timeout=timeout)
+        time.sleep(args.pairtime + 0.5)
+        self.stick.sync_devices()
+        print("Pairing done, Config file updated.")
+
+    def do_remote(self, args):
+        code = args[0][0:6]
+        timeout = int(args[1])
+        self.stick.remote(code, timeout)
         time.sleep(args.pairtime + 0.5)
         self.stick.sync_devices()
         print("Pairing done, Config file updated.")
@@ -299,6 +310,16 @@ if __name__ == "__main__":
         stick._initialize()
         stick.start()
         stick.unpair(timeout=args.pairtime)
+        time.sleep(args.pairtime + 0.5)
+        stick.sync_devices()
+        print("""""")
+
+    if args.remote:
+        print("entering remote pairing mode")
+        stick._initialize()
+        stick.start()
+        stick.pair(timeout=args.pairtime)
+        stick.remote(code=args.remote, timeout=args.pairtime)
         time.sleep(args.pairtime + 0.5)
         stick.sync_devices()
         print("""""")


### PR DESCRIPTION
Hello gluap,
I have a somewhat larger installation with 16 actors (2-Kanal-Aktor and Rohrmotor-Aktor), but no sensors at my parents place.
Lately, their Homepilot 2 box broke down, so I decided to give HA with your Rademacher component a try.
1. I had no access to the actors, so I implemented a remote binding through your CLI.
2. Status messages returned an IndexError, turns out code + '01' does not work. It looks this is related to the 2nd switch in the actor (which does not work right now), but it does not crash. I'll look into that.
3. 2-Kanal-Aktor was added as a shutter, not light in HA.
Apart from some minor issues, the solution works pretty well.