### PR TITLE
Implement HA subscription for cover entities

### DIFF
--- a/examples/homeassistant/custom_components/duofern/__init__.py
+++ b/examples/homeassistant/custom_components/duofern/__init__.py
@@ -70,7 +70,10 @@ def setup(hass, config):
             try:
                 device = hass.data[DOMAIN]['devices'][id] # Get device by id
                 if not device.should_poll: # Only trigger update if this entity is not polling
-                    device.schedule_update_ha_state(True) # Trigger update on the updated entity
+                    try:
+                        device.schedule_update_ha_state(True) # Trigger update on the updated entity
+                    except AssertionError:
+                        _LOGGER.debug("Update callback called before HA is ready") # Ignore updates before HA is ready
             except KeyError:
                 _LOGGER.debug("Update callback called on unknown device id") # Ignore invalid device ids
 

--- a/examples/homeassistant/custom_components/duofern/__init__.py
+++ b/examples/homeassistant/custom_components/duofern/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import time
 
 # from homeassistant.const import 'serial_port', 'config_file', 'code'
 import homeassistant.helpers.config_validation as cv
@@ -111,6 +112,7 @@ def setup(hass, config):
 
     stick.add_updates_callback(update_callback)
 
-    stick.start()
+    time.sleep(5) # Wait for 5 seconds so HA can get our entities ready so we don't miss any updates (there are probably nicer ways to do this)
+    stick.start() # Start the stick after 5 seconds
 
     return True

--- a/examples/homeassistant/custom_components/duofern/binary_sensor.py
+++ b/examples/homeassistant/custom_components/duofern/binary_sensor.py
@@ -41,6 +41,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
 
 class DuofernSmokeDetector(BinarySensorEntity):
+    """Duofern smoke detector entity"""
+
     def __init__(self, code, desc, stick, hass, channel=None):
         """Initialize the smoke detector"""
 
@@ -90,7 +92,7 @@ class DuofernSmokeDetector(BinarySensorEntity):
 
     @property
     def should_poll(self):
-        """Whether this entity should be polled or uses trigger_update"""
+        """Whether this entity should be polled or uses subscriptions"""
         return False # TODO: Add config option for subscriptions over polling
 
     @property

--- a/examples/homeassistant/custom_components/duofern/cover.py
+++ b/examples/homeassistant/custom_components/duofern/cover.py
@@ -31,7 +31,6 @@ class DuofernShutter(CoverEntity):
         self._id = id
         self._name = desc
         self._state = None
-        self._brightness = None
         self._stick = stick
         hass.data[DOMAIN]['devices'][id] = self
 
@@ -42,18 +41,17 @@ class DuofernShutter(CoverEntity):
     @property
     def current_cover_position(self):
         """Return the display name of this cover."""
-        try:
-            return 100 - self._stick.duofern_parser.modules['by_code'][self._id]['position']
-        except KeyError:
-            return None
+        return self._state
 
     @property
     def is_closed(self):
         """Return true if cover is close."""
-        try:
-            return self._stick.duofern_parser.modules['by_code'][self._id]['position'] == 100
-        except KeyError:
-            return False
+        return self._state == 100
+
+    @property
+    def should_poll(self):
+        """Whether this entity should be polled or uses subscriptions"""
+        return False # TODO: Add config option for subscriptions over polling
 
     @property
     def unique_id(self):
@@ -77,13 +75,14 @@ class DuofernShutter(CoverEntity):
         self._stick.command(self._id, "position", 100 - position)
 
     def update(self):
-        """Fetch new state data for this light.
+        """Fetch new state data for this cover.
 
         This is the only method that should fetch new data for Home Assistant.
-        
+
         (no new data needs to be fetched, the stick updates itsself in a thread)
         (not the best style for homeassistant, I know. I'll port to asyncio if I find the time)
         """
-        pass
-        # self._state = True
-        # self._brightness = None
+        try:
+            self._state = 100 - self._stick.duofern_parser.modules['by_code'][self._id]['position']
+        except KeyError:
+            self._state = None


### PR DESCRIPTION
Covers now work without polling too, Home Assistant UI is really snappy now.

I don't have any lights so I left the light entities alone for now.

I had to add a 5 second delay before starting the stick in the custom component otherwise some entities wouldn't get their initial state because the update callback is called too early. There are probably better ways to do this but this works perfectly for now.