### PR TITLE
Save Serial port in config file

### DIFF
--- a/pyduofern/duofern_stick.py
+++ b/pyduofern/duofern_stick.py
@@ -438,17 +438,23 @@ class DuofernStickThreaded(DuofernStick, threading.Thread):
     def __init__(self, serial_port=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if serial_port is None:
+
+        self.port = None
+        if serial_port is not None:
+            self.port = serial_port
+            if not self.ephemeral:
+                self.config['port'] = serial_port
+                self._dump_config()
+        elif 'port' in self.config and not self.ephemeral:  # pragma: no cover
+            self.port = self.config['port']
+        else:
             try:
                 self.port = serial.tools.list_ports.comports()[0].device
             except IndexError:
                 raise DuofernException(
                     "No serial port configured and unable to autodetect device. Did you plug in your stick?")
             logger.debug("no serial port set, autodetected {} for duofern".format(self.port))
-        else:
-            self.port = serial_port
-
-        # DuofernStick.__init__(self, device, system_code, config_file_json, duofern_parser)
+        #print("used port:", self.port)
         self.serial_connection = serial.Serial(self.port, baudrate=115200, timeout=1)
         self.running = False
 

--- a/scripts/duofern_cli.py
+++ b/scripts/duofern_cli.py
@@ -25,9 +25,10 @@ from cmd import Cmd
 
 from pyduofern.duofern_stick import DuofernStickThreaded
 
+
 parser = argparse.ArgumentParser(epilog="use at your own risk")
 
-parser.add_argument('--configfile', help='location of system config file', default=None, metavar="CONFIGFILE")
+parser.add_argument('--configfile', help='location of system config file (if omitted the default config file will be used)', default=None, metavar="CONFIGFILE")
 
 parser.add_argument('--code', help='set 4-digit hex code for the system (warning, always use same code for once-paired '
                                    'devices) best chose something on the first run and write it down.',
@@ -35,7 +36,7 @@ parser.add_argument('--code', help='set 4-digit hex code for the system (warning
 
 parser.add_argument('--device',
                     help='path to serial port created by duofern stick, defaults to first found serial port, typically '
-                         'something like /dev/ttyUSB0 or /dev/duofernstick if you use the provided udev rules file',
+                         'something like /dev/ttyUSB0 or /dev/serial/by-id/... or /dev/duofernstick if you use the provided udev rules file',
                     default=None)
 
 parser.add_argument('--pair', action='store_true',
@@ -269,7 +270,6 @@ class DuofernCLI(Cmd):
 if __name__ == "__main__":
     args = parser.parse_args()
 
-    # print(args.up)
     if args.debug:
         logging.basicConfig(format='    %(asctime)s: %(message)s', level=logging.DEBUG)
     else:


### PR DESCRIPTION
Small improvement for working with cli script:
Now the serial port of the stick needs to get passed to the cli script only once (via the --device parameter). 
It then gets saved in the config file (like the system code) and will be used from there the next time calling the script without --device parameter.